### PR TITLE
распараллеливание по частицам; новый формат выходных фаилов. 

### DIFF
--- a/External_magnetic_field.cpp
+++ b/External_magnetic_field.cpp
@@ -27,7 +27,7 @@ Vec3d External_magnetic_field::force_on_particle( Particle &p )
 			       scale );
 }
 
-void External_magnetic_field::write_to_file( std::ofstream &output_file )
+void External_magnetic_field::write_to_file_iostream( std::ofstream &output_file )
 {
     std::cout.precision( 3 );
     std::cout.setf( std::ios::scientific );
@@ -40,5 +40,30 @@ void External_magnetic_field::write_to_file( std::ofstream &output_file )
 		<< vec3d_z( magnetic_field ) << " )" 	
 		<< std::endl;
     output_file << "Speed of light = " << speed_of_light << std::endl;
+    return;
+}
+
+void External_magnetic_field::write_to_file_hdf5( hid_t hdf5_file_id )
+{
+    double H_x = vec3d_x( magnetic_field );
+    double H_y = vec3d_y( magnetic_field );
+    double H_z = vec3d_z( magnetic_field );
+
+    hid_t group_id;
+    herr_t status;
+    int single_element = 1;
+    std::string hdf5_groupname = "/External_magnetic_field";
+    group_id = H5Gcreate2( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+			      "external_magnetic_field_x", &H_x, single_element );
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+			      "external_magnetic_field_y", &H_y, single_element );
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+			      "external_magnetic_field_z", &H_z, single_element );
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+			      "speed_of_light", &speed_of_light, single_element );
+    
+    status = H5Gclose(group_id);	
     return;
 }

--- a/External_magnetic_field.cpp
+++ b/External_magnetic_field.cpp
@@ -27,23 +27,7 @@ Vec3d External_magnetic_field::force_on_particle( Particle &p )
 			       scale );
 }
 
-void External_magnetic_field::write_to_file_iostream( std::ofstream &output_file )
-{
-    std::cout.precision( 3 );
-    std::cout.setf( std::ios::scientific );
-    std::cout.fill(' ');
-    std::cout.setf( std::ios::right );
-    output_file << "###External_magnetic_field" << std::endl;
-    output_file << "External_magnetic_field(x,y,z) = ( "
-		<< vec3d_x( magnetic_field ) << " " 
-		<< vec3d_y( magnetic_field ) << " " 
-		<< vec3d_z( magnetic_field ) << " )" 	
-		<< std::endl;
-    output_file << "Speed of light = " << speed_of_light << std::endl;
-    return;
-}
-
-void External_magnetic_field::write_to_file_hdf5( hid_t hdf5_file_id )
+void External_magnetic_field::write_to_file( hid_t hdf5_file_id )
 {
     double H_x = vec3d_x( magnetic_field );
     double H_y = vec3d_y( magnetic_field );
@@ -53,17 +37,32 @@ void External_magnetic_field::write_to_file_hdf5( hid_t hdf5_file_id )
     herr_t status;
     int single_element = 1;
     std::string hdf5_groupname = "/External_magnetic_field";
-    group_id = H5Gcreate2( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    group_id = H5Gcreate2( hdf5_file_id, hdf5_groupname.c_str(),
+			   H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); hdf5_status_check( group_id );
 
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
-			      "external_magnetic_field_x", &H_x, single_element );
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
-			      "external_magnetic_field_y", &H_y, single_element );
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
-			      "external_magnetic_field_z", &H_z, single_element );
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
-			      "speed_of_light", &speed_of_light, single_element );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "external_magnetic_field_x", &H_x, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "external_magnetic_field_y", &H_y, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "external_magnetic_field_z", &H_z, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "speed_of_light", &speed_of_light, single_element );
+    hdf5_status_check( status );
     
-    status = H5Gclose(group_id);
+    status = H5Gclose(group_id); hdf5_status_check( status );
     return;
 }
+
+void External_magnetic_field::hdf5_status_check( herr_t status )
+{
+    if( status < 0 ){
+	std::cout << "Something went wrong while writing External_magnetic_field group."
+		  << "Aborting." << std::endl;
+	exit( EXIT_FAILURE );
+    }
+}
+

--- a/External_magnetic_field.cpp
+++ b/External_magnetic_field.cpp
@@ -64,6 +64,6 @@ void External_magnetic_field::write_to_file_hdf5( hid_t hdf5_file_id )
     H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
 			      "speed_of_light", &speed_of_light, single_element );
     
-    status = H5Gclose(group_id);	
+    status = H5Gclose(group_id);
     return;
 }

--- a/External_magnetic_field.h
+++ b/External_magnetic_field.h
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <iomanip>
+#include <hdf5.h>
+#include <hdf5_hl.h>
 #include "config.h"
 #include "particle.h"
 #include "vec3d.h"
@@ -15,7 +17,8 @@ public:
 public:    
     External_magnetic_field( Config &conf );
     Vec3d force_on_particle( Particle &p );
-    void write_to_file( std::ofstream &output_file );
+    void write_to_file_iostream( std::ofstream &output_file );
+    void write_to_file_hdf5( hid_t hdf5_file_id );
     virtual ~External_magnetic_field() {};
 private:
     void check_correctness_of_related_config_fields( Config &conf );

--- a/External_magnetic_field.h
+++ b/External_magnetic_field.h
@@ -18,12 +18,12 @@ public:
 public:    
     External_magnetic_field( Config &conf );
     Vec3d force_on_particle( Particle &p );
-    void write_to_file_iostream( std::ofstream &output_file );
-    void write_to_file_hdf5( hid_t hdf5_file_id );
+    void write_to_file( hid_t hdf5_file_id );
     virtual ~External_magnetic_field() {};
 private:
     void check_correctness_of_related_config_fields( Config &conf );
     void get_values_from_config( Config &conf );
+    void hdf5_status_check( herr_t status );
 };
 
 #endif /* _EXTERNAL_MAGNETIC_FIELD_H_ */

--- a/External_magnetic_field.h
+++ b/External_magnetic_field.h
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <hdf5.h>
 #include <hdf5_hl.h>
+#include <mpi.h>
 #include "config.h"
 #include "particle.h"
 #include "vec3d.h"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL:=/bin/bash -O extglob
 ##### Prll
 #export OMPI_CXX=clang++
 CC = mpic++
-HDF5FLAGS=-I/usr/include/hdf5/serial -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_BSD_SOURCE -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security
+HDF5FLAGS=-I/usr/include/hdf5/openmpi -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_BSD_SOURCE -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security
 PETSCFLAGS=-isystem /usr/include/petsc
 OCEFLAGS=-isystem /usr/include/oce
 SUPPRESS_MPI_C11_WARNING=-Wno-literal-suffix
@@ -18,7 +18,7 @@ COMMONLIBS=-lm -fsanitize=address
 SANITIZER=-lasan
 BOOSTLIBS=-lboost_program_options
 PETSCLIBS=-lpetsc
-HDF5LIBS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5 -Wl,-z,relro -lpthread -lz -ldl -lm -Wl,-rpath -Wl,/usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5LIBS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5 -Wl,-z,relro -lpthread -lz -ldl -lm -Wl,-rpath -Wl,/usr/lib/x86_64-linux-gnu/hdf5/openmpi
 OPENCASCADELIBS=-lTKXSBase -lTKernel -lTKBRep -lTKMath -lTKSTEP -lTKBool -lTKTopAlgo -lTKPrim
 LIBS=${COMMONLIBS} ${BOOSTLIBS} ${PETSCLIBS} ${HDF5LIBS} ${OPENCASCADELIBS} ${SANITIZER}
 

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,22 @@ SHELL:=/bin/bash -O extglob
 ##### Prll
 #export OMPI_CXX=clang++
 CC = mpic++
-CFLAGS = -isystem /usr/include/petsc -isystem /usr/include/oce -O2 -std=c++11 -Wall -fbounds-check -Warray-bounds -fsanitize=address
+HDF5FLAGS=-I/usr/include/hdf5/serial -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_BSD_SOURCE -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security
+PETSCFLAGS=-isystem /usr/include/petsc
+OCEFLAGS=-isystem /usr/include/oce
+SUPPRESS_MPI_C11_WARNING=-Wno-literal-suffix
+WARNINGS=-Wall -fbounds-check -Warray-bounds -fsanitize=address
+CFLAGS = ${HDF5FLAGS} ${PETSCFLAGS} ${OCEFLAGS} -O2 -std=c++11 ${WARNINGS} ${SUPPRESS_MPI_C11_WARNING}
 LDFLAGS = 
 
 ### Libraries
-COMMONLIBS=-lm
+COMMONLIBS=-lm -fsanitize=address
 SANITIZER=-lasan
 BOOSTLIBS=-lboost_program_options
 PETSCLIBS=-lpetsc
+HDF5LIBS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5 -Wl,-z,relro -lpthread -lz -ldl -lm -Wl,-rpath -Wl,/usr/lib/x86_64-linux-gnu/hdf5/serial
 OPENCASCADELIBS=-lTKXSBase -lTKernel -lTKBRep -lTKMath -lTKSTEP -lTKBool -lTKTopAlgo -lTKPrim
-LIBS=${COMMONLIBS} ${BOOSTLIBS} ${PETSCLIBS} ${OPENCASCADELIBS} ${SANITIZER}
+LIBS=${COMMONLIBS} ${BOOSTLIBS} ${PETSCLIBS} ${HDF5LIBS} ${OPENCASCADELIBS} ${SANITIZER}
 
 ### Sources and executable
 CPPSOURCES=$(wildcard *.cpp)

--- a/config.cpp
+++ b/config.cpp
@@ -25,10 +25,10 @@ Config::Config( const std::string &filename )
 		std::string inner_region_name = section_name.substr( section_name.find(".") + 1 );
 		inner_regions_config_part.push_back(
 		    new Inner_region_sphere_config_part( inner_region_name, sections.second ) );
-	    } else if ( section_name.find( "Inner_region_with_model." ) != std::string::npos ) {
+	    } else if ( section_name.find( "Inner_region_STEP." ) != std::string::npos ) {
 		std::string inner_region_name = section_name.substr( section_name.find(".") + 1 );
 		inner_regions_config_part.push_back(
-		    new Inner_region_with_model_config_part( inner_region_name, sections.second ));
+		    new Inner_region_STEP_config_part( inner_region_name, sections.second ));
 	    } else if ( section_name.find( "Boundary conditions" ) != std::string::npos ) {
 		boundary_config_part = Boundary_config_part( sections.second );
 	    } else if ( section_name.find( "External magnetic field" ) != std::string::npos ) {

--- a/config.h
+++ b/config.h
@@ -132,8 +132,8 @@ public:
 	{};	
     virtual ~Inner_region_config_part() {};
     virtual void print() {
-	std::cout << "Inner_region_with_model_name = " << inner_region_name << std::endl;
-	std::cout << "Inner_region_with_model_potential = " << inner_region_potential << std::endl;
+	std::cout << "Inner_region_STEP_name = " << inner_region_name << std::endl;
+	std::cout << "Inner_region_STEP_potential = " << inner_region_potential << std::endl;
     }
 };
 
@@ -197,21 +197,21 @@ public:
     }
 };
 
-class Inner_region_with_model_config_part : public Inner_region_config_part {
-public:
-    std::string inner_region_with_model_file;
-public:
-    Inner_region_with_model_config_part(){};
-    Inner_region_with_model_config_part( std::string name, boost::property_tree::ptree &ptree ) :
-	inner_region_with_model_file( ptree.get<std::string>("inner_region_with_model_file") ) {
-	    inner_region_name = name;
-	    inner_region_potential = ptree.get<double>("inner_region_with_model_potential");
-	};
-    virtual ~Inner_region_with_model_config_part() {};
+class Inner_region_STEP_config_part : public Inner_region_config_part {
+  public:
+    std::string inner_region_STEP_file;
+  public:
+    Inner_region_STEP_config_part(){};
+  Inner_region_STEP_config_part( std::string name, boost::property_tree::ptree &ptree ) :
+    inner_region_STEP_file( ptree.get<std::string>("inner_region_STEP_file") ) {
+	inner_region_name = name;
+	inner_region_potential = ptree.get<double>("inner_region_STEP_potential");
+    };
+    virtual ~Inner_region_STEP_config_part() {};
     void print() {
-	std::cout << "Inner_region_with_model_name = " << inner_region_name << std::endl;
-	std::cout << "Inner_region_with_model_potential = " << inner_region_potential << std::endl;
-	std::cout << "Inner_region_with_model_file = " << inner_region_with_model_file << std::endl;
+	std::cout << "Inner_region_STEP_name = " << inner_region_name << std::endl;
+	std::cout << "Inner_region_STEP_potential = " << inner_region_potential << std::endl;
+	std::cout << "Inner_region_STEP_file = " << inner_region_STEP_file << std::endl;
     }
 };
 

--- a/domain.cpp
+++ b/domain.cpp
@@ -59,6 +59,7 @@ void Domain::prepare_leap_frog()
 
 void Domain::advance_one_time_step()
 {
+    particle_sources.print_particles();
     push_particles();
     apply_domain_constrains();
     eval_charge_density();
@@ -71,6 +72,7 @@ void Domain::eval_charge_density()
 {
     spat_mesh.clear_old_density_values();
     particle_to_mesh_map.weight_particles_charge_to_mesh( spat_mesh, particle_sources );
+    
     return;
 }
 

--- a/domain.h
+++ b/domain.h
@@ -61,11 +61,8 @@ class Domain {
     void generate_new_particles();    
     // Various functions
     void print_particles();
-    void write_iostream( Config &conf );
-    void write_hdf5( Config &conf );
-    void eval_and_write_fields_without_particles_iostream( Config &conf );
-    void eval_and_write_fields_without_particles_hdf5( Config &conf );
     bool negative( hid_t hdf5_id );
+    void hdf5_status_check( herr_t status );
 };
 
 #endif /* _DOMAIN_H_ */

--- a/domain.h
+++ b/domain.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <algorithm>
 #include <functional>
+#include <mpi.h>
+#include <hdf5.h>
 #include "config.h"
 #include "time_grid.h"
 #include "spatial_mesh.h"
@@ -56,9 +58,14 @@ class Domain {
     // Boundaries and generation
     void apply_domain_boundary_conditions();
     bool out_of_bound( const Particle &p );
-    void generate_new_particles();
+    void generate_new_particles();    
     // Various functions
     void print_particles();
+    void write_iostream( Config &conf );
+    void write_hdf5( Config &conf );
+    void eval_and_write_fields_without_particles_iostream( Config &conf );
+    void eval_and_write_fields_without_particles_hdf5( Config &conf );
+    bool negative( hid_t hdf5_id );
 };
 
 #endif /* _DOMAIN_H_ */

--- a/domain.h
+++ b/domain.h
@@ -29,7 +29,7 @@ class Domain {
     Inner_regions_manager inner_regions;
     Particle_to_mesh_map particle_to_mesh_map;
     Field_solver field_solver;    
-    Particle_sources particle_sources;
+    Particle_sources_manager particle_sources;
     External_magnetic_field external_magnetic_field;
   public:
     Domain( Config &conf );

--- a/field_solver.cpp
+++ b/field_solver.cpp
@@ -611,7 +611,7 @@ void Field_solver::set_rhs_at_nodes_occupied_by_objects( Spatial_mesh &spat_mesh
     PetscInt num_of_elements = indices_of_inner_nodes_not_at_domain_edge.size();
     if( num_of_elements != 0 ){
 	PetscInt *global_indices = &indices_of_inner_nodes_not_at_domain_edge[0];
-	std::vector<PetscScalar> zeroes(num_of_elements, 0.0);
+	std::vector<PetscScalar> zeroes( num_of_elements, 0.0 );
     
 	ierr = VecSetValues( rhs, num_of_elements, global_indices, &zeroes[0], INSERT_VALUES );
 	CHKERRXX( ierr );

--- a/field_solver.h
+++ b/field_solver.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <petscksp.h>
+#include <mpi.h>
 #include <boost/multi_array.hpp>
 #include <vector>
 #include "spatial_mesh.h"

--- a/inner_region.cpp
+++ b/inner_region.cpp
@@ -181,34 +181,34 @@ bool Inner_region_sphere::check_if_point_inside( double x, double y, double z )
 
 // Step model
 
-Inner_region_with_model::Inner_region_with_model( Config &conf,
-						  Inner_region_with_model_config_part &inner_region_with_model_conf,
-						  Spatial_mesh &spat_mesh )
+Inner_region_STEP::Inner_region_STEP( Config &conf,
+				      Inner_region_STEP_config_part &inner_region_STEP_conf,
+				      Spatial_mesh &spat_mesh )
 {
-    check_correctness_of_related_config_fields( conf, inner_region_with_model_conf );
-    get_values_from_config( inner_region_with_model_conf );
+    check_correctness_of_related_config_fields( conf, inner_region_STEP_conf );
+    get_values_from_config( inner_region_STEP_conf );
     mark_inner_nodes( spat_mesh );
     select_inner_nodes_not_at_domain_edge( spat_mesh );
     mark_near_boundary_nodes( spat_mesh );
     select_near_boundary_nodes_not_at_domain_edge( spat_mesh );
 }
 
-void Inner_region_with_model::check_correctness_of_related_config_fields(
+void Inner_region_STEP::check_correctness_of_related_config_fields(
     Config &conf,
-    Inner_region_with_model_config_part &inner_region_with_model_conf )
+    Inner_region_STEP_config_part &inner_region_STEP_conf )
 {
   // Check if file exists?   
 }
 
-void Inner_region_with_model::get_values_from_config( Inner_region_with_model_config_part &inner_region_with_model_conf )
+void Inner_region_STEP::get_values_from_config( Inner_region_STEP_config_part &inner_region_STEP_conf )
 {
-    name = inner_region_with_model_conf.inner_region_name;
-    potential = inner_region_with_model_conf.inner_region_potential;
-    read_geometry_file( inner_region_with_model_conf.inner_region_with_model_file );
+    name = inner_region_STEP_conf.inner_region_name;
+    potential = inner_region_STEP_conf.inner_region_potential;
+    read_geometry_file( inner_region_STEP_conf.inner_region_STEP_file );
 
 }
 
-void Inner_region_with_model::read_geometry_file( std::string filename )
+void Inner_region_STEP::read_geometry_file( std::string filename )
 {
   STEPControl_Reader reader;
   reader.ReadFile( filename.c_str() );
@@ -224,14 +224,14 @@ void Inner_region_with_model::read_geometry_file( std::string filename )
 
   geometry = reader.OneShape();
   if (geometry.IsNull() || geometry.ShapeType() != TopAbs_SOLID) {
-      std::cout << "Something wrong with model of inner_region_with_model: "
+      std::cout << "Something wrong with model of inner_region_STEP: "
   		<< name
   		<< std::endl;
       exit( EXIT_FAILURE );
   }
 }
 
-bool Inner_region_with_model::check_if_point_inside( double x, double y, double z )
+bool Inner_region_STEP::check_if_point_inside( double x, double y, double z )
 {
     gp_Pnt point(x, y, z);
     BRepClass3d_SolidClassifier solidClassifier( geometry, point, Precision::Confusion() );
@@ -252,7 +252,7 @@ bool Inner_region_with_model::check_if_point_inside( double x, double y, double 
     }
 }
 
-Inner_region_with_model::~Inner_region_with_model()
+Inner_region_STEP::~Inner_region_STEP()
 {
     // todo
 }

--- a/inner_region.h
+++ b/inner_region.h
@@ -119,21 +119,21 @@ private:
 
 
 
-class Inner_region_with_model : public Inner_region
+class Inner_region_STEP : public Inner_region
 {
 public:
     TopoDS_Shape geometry;
     const double tolerance = 0.001;
 public:
-    Inner_region_with_model( Config &conf,
-			     Inner_region_with_model_config_part &inner_region_with_model_conf,
+    Inner_region_STEP( Config &conf,
+			     Inner_region_STEP_config_part &inner_region_STEP_conf,
 			     Spatial_mesh &spat_mesh );
     virtual bool check_if_point_inside( double x, double y, double z );
-    virtual ~Inner_region_with_model();
+    virtual ~Inner_region_STEP();
 private:
     void check_correctness_of_related_config_fields( Config &conf,
-						     Inner_region_with_model_config_part &inner_region_with_model_conf );
-    void get_values_from_config( Inner_region_with_model_config_part &inner_region_with_model_conf );    
+						     Inner_region_STEP_config_part &inner_region_STEP_conf );
+    void get_values_from_config( Inner_region_STEP_config_part &inner_region_STEP_conf );    
     void read_geometry_file( std::string filename );
 };
 
@@ -155,12 +155,12 @@ public:
 		regions.push_back( new Inner_region_sphere( conf,
 							    *sphere_conf,
 							    spat_mesh ) );
-	    } else if (	Inner_region_with_model_config_part *with_model_conf =
-			dynamic_cast<Inner_region_with_model_config_part*>(
+	    } else if (	Inner_region_STEP_config_part *with_model_conf =
+			dynamic_cast<Inner_region_STEP_config_part*>(
 			    &inner_region_conf ) ) {
-		regions.push_back( new Inner_region_with_model( conf,
-								*with_model_conf,
-								spat_mesh ) );
+		regions.push_back( new Inner_region_STEP( conf,
+							  *with_model_conf,
+							  spat_mesh ) );
 	    } else {
 		std::cout << "In Inner_regions_manager constructor: Unknown config type. Aborting" << std::endl; 
 		exit( EXIT_FAILURE );

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@ int main( int argc, char *argv[] )
     ierr = MPI_Comm_size( PETSC_COMM_WORLD, &mpi_comm_size); CHKERRXX(ierr);
     MPI_Comm_rank( PETSC_COMM_WORLD, &mpi_process_rank );
 
+
     //// Parse command line
     parse_cmd_line( argc, argv, config_file );
     //// Read config

--- a/node_reference.h
+++ b/node_reference.h
@@ -50,12 +50,12 @@ public:
     };
 
     // comparison operators are necessary for std::sort and std::unique to work
-    bool operator< ( const Node_reference &other_node ){
+    bool operator< ( const Node_reference &other_node ) const {
 	return ( x < other_node.x ) ||
 	       ( x == other_node.x && y < other_node.y ) ||
 	       ( x == other_node.x && y == other_node.y && z < other_node.z );
     };
-    bool operator== ( const Node_reference &other_node ){
+    bool operator== ( const Node_reference &other_node ) const {
 	return x == other_node.x && y == other_node.y && z == other_node.z;
     };
     

--- a/particle.cpp
+++ b/particle.cpp
@@ -51,3 +51,53 @@ void Particle::print_short()
 	      << std::endl;
     return;
 }
+
+
+hid_t HDF5_buffer_for_Particle_compound_type_for_memory()
+{
+    hid_t compound_type_for_mem;
+    herr_t status;
+
+    hid_t vec3d_compound_type_for_mem;
+    vec3d_compound_type_for_mem = vec3d_hdf5_compound_type_for_memory();
+    
+    compound_type_for_mem = H5Tcreate( H5T_COMPOUND, sizeof(HDF5_buffer_for_Particle) );
+    status = H5Tinsert( compound_type_for_mem, "id",
+			HOFFSET( HDF5_buffer_for_Particle, id ), H5T_NATIVE_INT );
+    status = H5Tinsert( compound_type_for_mem, "charge",
+			HOFFSET( HDF5_buffer_for_Particle, charge ), H5T_NATIVE_DOUBLE );
+    status = H5Tinsert( compound_type_for_mem, "mass",
+			HOFFSET( HDF5_buffer_for_Particle, mass ), H5T_NATIVE_DOUBLE );
+    status = H5Tinsert( compound_type_for_mem, "position",
+			HOFFSET( HDF5_buffer_for_Particle, position ), vec3d_compound_type_for_mem );
+    status = H5Tinsert( compound_type_for_mem, "momentum",
+			HOFFSET( HDF5_buffer_for_Particle, momentum ), vec3d_compound_type_for_mem );
+    status = H5Tinsert( compound_type_for_mem, "mpi_proc_rank",
+			HOFFSET( HDF5_buffer_for_Particle, mpi_proc_rank ), H5T_NATIVE_INT );
+
+    status = H5Tclose( vec3d_compound_type_for_mem );
+    
+    return compound_type_for_mem;
+}
+
+hid_t HDF5_buffer_for_Particle_compound_type_for_file()
+{
+    hid_t compound_type_for_file;
+    herr_t status;
+
+    hid_t vec3d_compound_type_for_file;
+    vec3d_compound_type_for_file = vec3d_hdf5_compound_type_for_file();
+    
+    compound_type_for_file = H5Tcreate( H5T_COMPOUND, 4 + 8 + 8 + 3*8 + 3*8 + 4 );
+    status = H5Tinsert( compound_type_for_file, "id", 0, H5T_STD_I32BE );
+    status = H5Tinsert( compound_type_for_file, "charge", 4, H5T_IEEE_F64BE );
+    status = H5Tinsert( compound_type_for_file, "mass", 4 + 8, H5T_IEEE_F64BE );
+    status = H5Tinsert( compound_type_for_file, "position", 4 + 8 + 8, vec3d_compound_type_for_file );
+    status = H5Tinsert( compound_type_for_file, "momentum", 4 + 8 + 8 + 3*8, vec3d_compound_type_for_file );
+    status = H5Tinsert( compound_type_for_file, "mpi_proc_rank", 4 + 8 + 8 + 3*8 + 3*8, H5T_STD_I32BE );
+
+    status = H5Tclose( vec3d_compound_type_for_file );
+    
+    return compound_type_for_file;
+}
+

--- a/particle.cpp
+++ b/particle.cpp
@@ -62,20 +62,29 @@ hid_t HDF5_buffer_for_Particle_compound_type_for_memory()
     vec3d_compound_type_for_mem = vec3d_hdf5_compound_type_for_memory();
     
     compound_type_for_mem = H5Tcreate( H5T_COMPOUND, sizeof(HDF5_buffer_for_Particle) );
+        HDF5_buffer_for_Particle_hdf5_status_check( compound_type_for_mem );
+
     status = H5Tinsert( compound_type_for_mem, "id",
 			HOFFSET( HDF5_buffer_for_Particle, id ), H5T_NATIVE_INT );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "charge",
 			HOFFSET( HDF5_buffer_for_Particle, charge ), H5T_NATIVE_DOUBLE );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "mass",
 			HOFFSET( HDF5_buffer_for_Particle, mass ), H5T_NATIVE_DOUBLE );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "position",
 			HOFFSET( HDF5_buffer_for_Particle, position ), vec3d_compound_type_for_mem );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "momentum",
 			HOFFSET( HDF5_buffer_for_Particle, momentum ), vec3d_compound_type_for_mem );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "mpi_proc_rank",
 			HOFFSET( HDF5_buffer_for_Particle, mpi_proc_rank ), H5T_NATIVE_INT );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
 
     status = H5Tclose( vec3d_compound_type_for_mem );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     
     return compound_type_for_mem;
 }
@@ -89,15 +98,32 @@ hid_t HDF5_buffer_for_Particle_compound_type_for_file()
     vec3d_compound_type_for_file = vec3d_hdf5_compound_type_for_file();
     
     compound_type_for_file = H5Tcreate( H5T_COMPOUND, 4 + 8 + 8 + 3*8 + 3*8 + 4 );
+        HDF5_buffer_for_Particle_hdf5_status_check( compound_type_for_file );
+
     status = H5Tinsert( compound_type_for_file, "id", 0, H5T_STD_I32BE );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_file, "charge", 4, H5T_IEEE_F64BE );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_file, "mass", 4 + 8, H5T_IEEE_F64BE );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_file, "position", 4 + 8 + 8, vec3d_compound_type_for_file );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_file, "momentum", 4 + 8 + 8 + 3*8, vec3d_compound_type_for_file );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_file, "mpi_proc_rank", 4 + 8 + 8 + 3*8 + 3*8, H5T_STD_I32BE );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
 
     status = H5Tclose( vec3d_compound_type_for_file );
+        HDF5_buffer_for_Particle_hdf5_status_check( status );
     
     return compound_type_for_file;
 }
 
+void HDF5_buffer_for_Particle_hdf5_status_check( herr_t status )
+{
+    if( status < 0 ){
+	std::cout << "Something went wrong while creating compound datatypes for HDF5_buffer_for_Particle. Aborting."
+		  << std::endl;
+	exit( EXIT_FAILURE );
+    }
+}

--- a/particle.h
+++ b/particle.h
@@ -21,4 +21,12 @@ class Particle {
     virtual ~Particle() {};
 };
 
+typedef struct {
+    int id;
+    double charge;
+    double mass;
+    Vec3d position;
+    Vec3d momentum;
+} HDF5_buffer_for_Particle;
+
 #endif /* _PARTICLE_H_ */

--- a/particle.h
+++ b/particle.h
@@ -27,6 +27,7 @@ typedef struct {
     double mass;
     Vec3d position;
     Vec3d momentum;
+    int mpi_proc_rank;
 } HDF5_buffer_for_Particle;
 
 #endif /* _PARTICLE_H_ */

--- a/particle.h
+++ b/particle.h
@@ -29,5 +29,8 @@ typedef struct {
     Vec3d momentum;
     int mpi_proc_rank;
 } HDF5_buffer_for_Particle;
+hid_t HDF5_buffer_for_Particle_compound_type_for_memory();
+hid_t HDF5_buffer_for_Particle_compound_type_for_file();
+
 
 #endif /* _PARTICLE_H_ */

--- a/particle.h
+++ b/particle.h
@@ -31,6 +31,6 @@ typedef struct {
 } HDF5_buffer_for_Particle;
 hid_t HDF5_buffer_for_Particle_compound_type_for_memory();
 hid_t HDF5_buffer_for_Particle_compound_type_for_file();
-
+void HDF5_buffer_for_Particle_hdf5_status_check( herr_t status );
 
 #endif /* _PARTICLE_H_ */

--- a/particle_source.cpp
+++ b/particle_source.cpp
@@ -188,7 +188,7 @@ void Particle_source::write_hdf5_particles( hid_t group_id, std::string table_of
 {
     herr_t status;
     int n_of_particles = particles.size();
-    int nfields = 5; // id, charge, mass, position, momentum
+    int nfields = 6; // id, charge, mass, position, momentum, mpi_proc_rank
     int nrecords = n_of_particles;
 
     // todo: dst_buf should be removed.
@@ -211,6 +211,7 @@ void Particle_source::write_hdf5_particles( hid_t group_id, std::string table_of
     dst_offset[2] = HOFFSET( HDF5_buffer_for_Particle, mass );
     dst_offset[3] = HOFFSET( HDF5_buffer_for_Particle, position );
     dst_offset[4] = HOFFSET( HDF5_buffer_for_Particle, momentum );
+    dst_offset[5] = HOFFSET( HDF5_buffer_for_Particle, mpi_proc_rank );
 
     const char *field_names[nfields];
     field_names[0] = "id";
@@ -218,6 +219,7 @@ void Particle_source::write_hdf5_particles( hid_t group_id, std::string table_of
     field_names[2] = "mass";
     field_names[3] = "position";
     field_names[4] = "momentum";
+    field_names[5] = "mpi_proc";
 
     hid_t vec3d_compound_type_for_mem;
     vec3d_compound_type_for_mem = vec3d_hdf5_compound_type_for_memory();
@@ -228,14 +230,18 @@ void Particle_source::write_hdf5_particles( hid_t group_id, std::string table_of
     field_type[2] = H5T_NATIVE_DOUBLE;
     field_type[3] = vec3d_compound_type_for_mem;
     field_type[4] = vec3d_compound_type_for_mem;
+    field_type[5] = H5T_NATIVE_INT;
 
     // todo: will become unnecessary when dst_buf is removed.
+    int mpi_process_rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_process_rank );    
     for( unsigned int i = 0; i < particles.size(); i++ ){
 	dst_buf[i].id = particles[i].id;
 	dst_buf[i].charge = particles[i].charge;
 	dst_buf[i].mass = particles[i].mass;
 	dst_buf[i].position = particles[i].position;
 	dst_buf[i].momentum = particles[i].momentum;
+	dst_buf[i].mpi_proc_rank = mpi_process_rank;
     }	
     
     hsize_t    chunk_size = 10;

--- a/particle_source.cpp
+++ b/particle_source.cpp
@@ -2,7 +2,7 @@
 
 void check_and_warn_if_not( const bool &should_be, const std::string &message );
 
-Single_particle_source::Single_particle_source( 
+Particle_source::Particle_source( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -11,7 +11,7 @@ Single_particle_source::Single_particle_source(
     generate_initial_particles();
 }
 
-void Single_particle_source::check_correctness_of_related_config_fields( 
+void Particle_source::check_correctness_of_related_config_fields( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -30,7 +30,7 @@ void Single_particle_source::check_correctness_of_related_config_fields(
     particle_source_mass_gt_zero( conf, src_conf );
 }
 
-void Single_particle_source::set_parameters_from_config( Source_config_part &src_conf )
+void Particle_source::set_parameters_from_config( Source_config_part &src_conf )
 {
     name = src_conf.particle_source_name;
     initial_number_of_particles = src_conf.particle_source_initial_number_of_particles;
@@ -53,19 +53,19 @@ void Single_particle_source::set_parameters_from_config( Source_config_part &src
     rnd_gen = std::default_random_engine( seed );
 }
 
-void Single_particle_source::generate_initial_particles()
+void Particle_source::generate_initial_particles()
 {
     //particles.reserve( initial_number_of_particles );
     generate_num_of_particles( initial_number_of_particles );
 }
 
-void Single_particle_source::generate_each_step()
+void Particle_source::generate_each_step()
 {
     //particles.reserve( particles.size() + particles_to_generate_each_step );
     generate_num_of_particles( particles_to_generate_each_step );
 }
     
-void Single_particle_source::generate_num_of_particles( int num_of_particles )
+void Particle_source::generate_num_of_particles( int num_of_particles )
 {
     Vec3d pos, mom;
     int id = 0;
@@ -79,7 +79,7 @@ void Single_particle_source::generate_num_of_particles( int num_of_particles )
 
 }
 
-int Single_particle_source::generate_particle_id( const int number )
+int Particle_source::generate_particle_id( const int number )
 {    
     // Preserve max id between calls to generator.
     static int last_id = 0;
@@ -87,7 +87,7 @@ int Single_particle_source::generate_particle_id( const int number )
     return last_id++;
 }
 
-Vec3d Single_particle_source::uniform_position_in_cube( 
+Vec3d Particle_source::uniform_position_in_cube( 
     const double xleft,  const double ytop, const double znear,
     const double xright, const double ybottom, const double zfar,
     std::default_random_engine &rnd_gen )
@@ -97,7 +97,7 @@ Vec3d Single_particle_source::uniform_position_in_cube(
 		       random_in_range( znear, zfar, rnd_gen ) );
 }
 
-double Single_particle_source::random_in_range( 
+double Particle_source::random_in_range( 
     const double low, const double up, 
     std::default_random_engine &rnd_gen )
 {
@@ -105,7 +105,7 @@ double Single_particle_source::random_in_range(
     return uniform_distr( rnd_gen );
 }
 
-Vec3d Single_particle_source::maxwell_momentum_distr(
+Vec3d Particle_source::maxwell_momentum_distr(
     const Vec3d mean_momentum, const double temperature, const double mass, 
     std::default_random_engine &rnd_gen )
 {    
@@ -128,14 +128,14 @@ Vec3d Single_particle_source::maxwell_momentum_distr(
     return mom;
 }
 
-void Single_particle_source::update_particles_position( double dt )
+void Particle_source::update_particles_position( double dt )
 {
     for ( auto &p : particles )
 	p.update_position( dt );
 }
 
 
-void Single_particle_source::print_particles()
+void Particle_source::print_particles()
 {
     std::cout << "Source name: " << name << std::endl;
     for ( auto& p : particles  ) {	
@@ -144,7 +144,7 @@ void Single_particle_source::print_particles()
     return;
 }
 
-void Single_particle_source::write_to_file( std::ofstream &output_file )
+void Particle_source::write_to_file( std::ofstream &output_file )
 {
     std::cout << "Source name = " << name << ", "
 	      << "number of particles = " << particles.size() 
@@ -171,7 +171,7 @@ void Single_particle_source::write_to_file( std::ofstream &output_file )
     return;
 }
 
-void Single_particle_source::particle_source_initial_number_of_particles_gt_zero( 
+void Particle_source::particle_source_initial_number_of_particles_gt_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -180,7 +180,7 @@ void Single_particle_source::particle_source_initial_number_of_particles_gt_zero
 	"particle_source_initial_number_of_particles <= 0" );
 }
 
-void Single_particle_source::particle_source_particles_to_generate_each_step_ge_zero( 
+void Particle_source::particle_source_particles_to_generate_each_step_ge_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -189,7 +189,7 @@ void Single_particle_source::particle_source_particles_to_generate_each_step_ge_
 	"particle_source_particles_to_generate_each_step < 0" );
 }
 
-void Single_particle_source::particle_source_x_left_ge_zero( 
+void Particle_source::particle_source_x_left_ge_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -198,7 +198,7 @@ void Single_particle_source::particle_source_x_left_ge_zero(
 	"particle_source_x_left < 0" );
 }
 
-void Single_particle_source::particle_source_x_left_le_particle_source_x_right( 
+void Particle_source::particle_source_x_left_le_particle_source_x_right( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -207,7 +207,7 @@ void Single_particle_source::particle_source_x_left_le_particle_source_x_right(
 	"particle_source_x_left > particle_source_x_right" );
 }
 
-void Single_particle_source::particle_source_x_right_le_grid_x_size( 
+void Particle_source::particle_source_x_right_le_grid_x_size( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -216,7 +216,7 @@ void Single_particle_source::particle_source_x_right_le_grid_x_size(
 	"particle_source_x_right > grid_x_size" );
 }
 
-void Single_particle_source::particle_source_y_bottom_ge_zero( 
+void Particle_source::particle_source_y_bottom_ge_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -225,7 +225,7 @@ void Single_particle_source::particle_source_y_bottom_ge_zero(
 	"particle_source_y_bottom < 0" );
 }
 
-void Single_particle_source::particle_source_y_bottom_le_particle_source_y_top( 
+void Particle_source::particle_source_y_bottom_le_particle_source_y_top( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -234,7 +234,7 @@ void Single_particle_source::particle_source_y_bottom_le_particle_source_y_top(
 	"particle_source_y_bottom > particle_source_y_top" );
 }
 
-void Single_particle_source::particle_source_y_top_le_grid_y_size( 
+void Particle_source::particle_source_y_top_le_grid_y_size( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -243,7 +243,7 @@ void Single_particle_source::particle_source_y_top_le_grid_y_size(
 	"particle_source_y_top > grid_y_size" );
 }
 
-void Single_particle_source::particle_source_z_near_ge_zero( 
+void Particle_source::particle_source_z_near_ge_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -252,7 +252,7 @@ void Single_particle_source::particle_source_z_near_ge_zero(
 	"particle_source_z_near < 0" );
 }
 
-void Single_particle_source::particle_source_z_near_le_particle_source_z_far( 
+void Particle_source::particle_source_z_near_le_particle_source_z_far( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -261,7 +261,7 @@ void Single_particle_source::particle_source_z_near_le_particle_source_z_far(
 	"particle_source_z_near > particle_source_z_far" );
 }
 
-void Single_particle_source::particle_source_z_far_le_grid_z_size( 
+void Particle_source::particle_source_z_far_le_grid_z_size( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -270,7 +270,7 @@ void Single_particle_source::particle_source_z_far_le_grid_z_size(
 	"particle_source_z_far > grid_z_size" );
 }
 
-void Single_particle_source::particle_source_temperature_gt_zero( 
+void Particle_source::particle_source_temperature_gt_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -279,7 +279,7 @@ void Single_particle_source::particle_source_temperature_gt_zero(
 	"particle_source_temperature < 0" );
 }
 
-void Single_particle_source::particle_source_mass_gt_zero( 
+void Particle_source::particle_source_mass_gt_zero( 
     Config &conf, 
     Source_config_part &src_conf )
 {
@@ -297,7 +297,7 @@ void check_and_warn_if_not( const bool &should_be, const std::string &message )
 }
 
 
-Particle_sources::Particle_sources( Config &conf )
+Particle_sources_manager::Particle_sources_manager( Config &conf )
 {
     for( auto &src_conf : conf.sources_config_part ) {
 	sources.emplace_back( conf, src_conf );

--- a/particle_source.cpp
+++ b/particle_source.cpp
@@ -49,8 +49,15 @@ void Particle_source::set_parameters_from_config( Source_config_part &src_conf )
     charge = src_conf.particle_source_charge;
     mass = src_conf.particle_source_mass;    
     // Random number generator
-    unsigned seed = 0;
+    // Simple approach: use different seed for each proccess.
+    // Other way would be to synchronize the state of the rnd_gen
+    //    between each processes after each call to it.    
+    int mpi_process_rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_process_rank );    
+    unsigned seed = 0 + 1000000*mpi_process_rank;
     rnd_gen = std::default_random_engine( seed );
+    // Initial id
+    max_id = 0;
 }
 
 void Particle_source::generate_initial_particles()
@@ -68,24 +75,69 @@ void Particle_source::generate_each_step()
 void Particle_source::generate_num_of_particles( int num_of_particles )
 {
     Vec3d pos, mom;
-    int id = 0;
-                
-    for ( int i = 0; i < num_of_particles; i++ ) {
-	id = generate_particle_id( i );
-	pos = uniform_position_in_cube( xleft, ytop, znear, xright, ybottom, zfar, rnd_gen );
+    std::vector<int> vec_of_ids;
+    int num_of_particles_for_this_proc;
+
+    int mpi_n_of_proc, mpi_process_rank;
+    MPI_Comm_size( MPI_COMM_WORLD, &mpi_n_of_proc );
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_process_rank );    
+
+    num_of_particles_for_each_process( &num_of_particles_for_this_proc,
+				       num_of_particles );
+    populate_vec_of_ids( vec_of_ids, num_of_particles_for_this_proc ); 
+    for ( int i = 0; i < num_of_particles_for_this_proc; i++ ) {
+	pos = uniform_position_in_cube( xleft, ytop, znear,
+					xright, ybottom, zfar,
+					rnd_gen );
 	mom = maxwell_momentum_distr( mean_momentum, temperature, mass, rnd_gen );
-	particles.emplace_back( id, charge, mass, pos, mom );
+	particles.emplace_back( vec_of_ids[i], charge, mass, pos, mom );
     }
-
 }
 
-int Particle_source::generate_particle_id( const int number )
-{    
-    // Preserve max id between calls to generator.
-    static int last_id = 0;
+void Particle_source::num_of_particles_for_each_process(
+    int *num_of_particles_for_this_proc,
+    int num_of_particles )
+{
+    int rest;
+    int mpi_n_of_proc, mpi_process_rank;
+    MPI_Comm_size( MPI_COMM_WORLD, &mpi_n_of_proc );
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_process_rank );    
     
-    return last_id++;
+    *num_of_particles_for_this_proc = num_of_particles / mpi_n_of_proc;
+    rest = num_of_particles % mpi_n_of_proc;
+    if( mpi_process_rank < rest ){
+	(*num_of_particles_for_this_proc)++;
+	// Processes with lesser ranks will accumulate
+	// more particles.
+	// This seems unessential.
+    }    
 }
+
+void Particle_source::populate_vec_of_ids(
+    std::vector<int> &vec_of_ids, int num_of_particles_for_this_proc )
+{
+    int mpi_n_of_proc, mpi_process_rank;
+    MPI_Comm_size( MPI_COMM_WORLD, &mpi_n_of_proc );
+    MPI_Comm_rank( MPI_COMM_WORLD, &mpi_process_rank );    
+
+    vec_of_ids.reserve( num_of_particles_for_this_proc );
+    
+    for( int proc = 0; proc < mpi_n_of_proc; proc++ ){
+	if( mpi_process_rank == proc ){
+	    for( int i = 0; i < num_of_particles_for_this_proc; i++ ){
+		vec_of_ids.push_back( max_id++ );
+	    }	    
+	}
+	MPI_Bcast( &max_id, 1, MPI_INT, proc, MPI_COMM_WORLD );
+    }
+}
+
+// int Particle_source::generate_particle_id( const int number, const int proc )
+// {
+//     max_id++;
+//     MPI_Bcast( &max_id, 1, MPI_UNSIGNED, proc, MPI_COMM_WORLD );
+//     return max_id;     
+// }
 
 Vec3d Particle_source::uniform_position_in_cube( 
     const double xleft,  const double ytop, const double znear,

--- a/particle_source.h
+++ b/particle_source.h
@@ -89,6 +89,8 @@ private:
     void write_hdf5_particles( hid_t group_id, std::string table_of_particles_name );
     void write_hdf5_source_parameters( hid_t group_id,
 				       std::string table_of_particles_name );
+    int n_of_elements_to_write_for_each_process_for_1d_dataset( int total_elements );
+    int data_offset_for_each_process_for_1d_dataset( int total_elements );
 };
 
 

--- a/particle_source.h
+++ b/particle_source.h
@@ -10,7 +10,7 @@
 #include "particle.h"
 #include "vec3d.h"
 
-class Single_particle_source{
+class Particle_source{
 private:
     std::string name;
     //
@@ -34,12 +34,12 @@ private:
 public:
     std::vector<Particle> particles;
 public:
-    Single_particle_source( Config &conf, Source_config_part &src_conf  );
+    Particle_source( Config &conf, Source_config_part &src_conf  );
     void generate_each_step();
     void update_particles_position( double dt );	
     void print_particles();
     void write_to_file( std::ofstream &output_file );
-    virtual ~Single_particle_source() {};
+    virtual ~Particle_source() {};
 private:
     // Particle initialization
     void set_parameters_from_config( Source_config_part &src_conf );
@@ -85,12 +85,12 @@ private:
 };
 
 
-class Particle_sources{
+class Particle_sources_manager{
 public:
-    std::vector<Single_particle_source> sources;
+    std::vector<Particle_source> sources;
 public:
-    Particle_sources( Config &conf );
-    virtual ~Particle_sources() {};
+    Particle_sources_manager( Config &conf );
+    virtual ~Particle_sources_manager() {};
     void write_to_file( std::ofstream &output_file ) 
     {
 	output_file << "### Particles" << std::endl;

--- a/particle_source.h
+++ b/particle_source.h
@@ -8,16 +8,19 @@
 #include <vector>
 #include <hdf5.h>
 #include <hdf5_hl.h>
+#include <mpi.h>
 #include "config.h"
 #include "particle.h"
 #include "vec3d.h"
 
 class Particle_source{
-private:
+public:
     std::string name;
-    //
+    std::vector<Particle> particles;
+private:
     int initial_number_of_particles;
     int particles_to_generate_each_step;
+    unsigned int max_id;
     // Source position
     double xleft;
     double xright;
@@ -34,9 +37,7 @@ private:
     // Random number generator
     std::default_random_engine rnd_gen;
 public:
-    std::vector<Particle> particles;
-public:
-    Particle_source( Config &conf, Source_config_part &src_conf  );
+    Particle_source( Config &conf, Source_config_part &src_conf );
     void generate_each_step();
     void update_particles_position( double dt );	
     void print_particles();
@@ -49,7 +50,11 @@ private:
     void generate_initial_particles();
     // Todo: replace 'std::default_random_engine' type with something more general.
     void generate_num_of_particles( int num_of_particles );
-    int generate_particle_id( const int number );
+    void num_of_particles_for_each_process( int *num_of_particles_for_this_proc,
+					    int num_of_particles );
+    void populate_vec_of_ids( std::vector<int> &vec_of_ids,
+			      int num_of_particles_for_this_proc );
+    //int generate_particle_id( const int number, const int proc );
     Vec3d uniform_position_in_cube( const double xleft, const double ytop, const double znear,
 				    const double xright, const double ybottom, const double zfar,
 				    std::default_random_engine &rnd_gen );

--- a/particle_to_mesh_map.cpp
+++ b/particle_to_mesh_map.cpp
@@ -1,7 +1,15 @@
 #include "particle_to_mesh_map.h"
 
-// Eval charge density on grid
+
 void Particle_to_mesh_map::weight_particles_charge_to_mesh( 
+    Spatial_mesh &spat_mesh, Particle_sources_manager &particle_sources  )
+{
+    weight_particles_charge_to_mesh_for_single_process( spat_mesh, particle_sources );
+    combine_charge_densities_from_all_processes( spat_mesh );
+}
+
+// Eval charge density on grid
+void Particle_to_mesh_map::weight_particles_charge_to_mesh_for_single_process( 
     Spatial_mesh &spat_mesh, Particle_sources_manager &particle_sources  )
 {
     // Rewrite:
@@ -43,6 +51,16 @@ void Particle_to_mesh_map::weight_particles_charge_to_mesh(
     return;
 }
 
+void Particle_to_mesh_map::combine_charge_densities_from_all_processes( Spatial_mesh &spat_mesh )
+{
+    // Hopefully, data arrangment in spat_mesh.charge_density is similar
+    // at each process. 
+    double *rho = spat_mesh.charge_density.data();
+    int n_of_elements = spat_mesh.charge_density.num_elements();
+    MPI_Allreduce(MPI_IN_PLACE, rho, n_of_elements, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+}
+
+    
 Vec3d Particle_to_mesh_map::force_on_particle( 
     Spatial_mesh &spat_mesh, Particle &p )
 {

--- a/particle_to_mesh_map.cpp
+++ b/particle_to_mesh_map.cpp
@@ -2,7 +2,7 @@
 
 // Eval charge density on grid
 void Particle_to_mesh_map::weight_particles_charge_to_mesh( 
-    Spatial_mesh &spat_mesh, Particle_sources &particle_sources  )
+    Spatial_mesh &spat_mesh, Particle_sources_manager &particle_sources  )
 {
     // Rewrite:
     // forall particles {

--- a/particle_to_mesh_map.h
+++ b/particle_to_mesh_map.h
@@ -10,7 +10,7 @@ class Particle_to_mesh_map {
     virtual ~Particle_to_mesh_map() {};
   public:
     void weight_particles_charge_to_mesh( 
-	Spatial_mesh &spat_mesh, Particle_sources &particle_sources );
+	Spatial_mesh &spat_mesh, Particle_sources_manager &particle_sources );
     Vec3d force_on_particle( 
 	Spatial_mesh &spat_mesh, Particle &p );
   private:

--- a/particle_to_mesh_map.h
+++ b/particle_to_mesh_map.h
@@ -1,3 +1,4 @@
+#include <mpi.h>
 #include "spatial_mesh.h"
 #include "particle_source.h"
 #include "particle.h"
@@ -9,10 +10,12 @@ class Particle_to_mesh_map {
     Particle_to_mesh_map() {};
     virtual ~Particle_to_mesh_map() {};
   public:
-    void weight_particles_charge_to_mesh( 
-	Spatial_mesh &spat_mesh, Particle_sources_manager &particle_sources );
-    Vec3d force_on_particle( 
-	Spatial_mesh &spat_mesh, Particle &p );
+    void weight_particles_charge_to_mesh( Spatial_mesh &spat_mesh,
+					  Particle_sources_manager &particle_sources );
+    void weight_particles_charge_to_mesh_for_single_process( Spatial_mesh &spat_mesh,
+							     Particle_sources_manager &particle_sources );
+    void combine_charge_densities_from_all_processes( Spatial_mesh &spat_mesh );
+    Vec3d force_on_particle( Spatial_mesh &spat_mesh, Particle &p );
   private:
     void next_node_num_and_weight( const double x, const double grid_step, 
 				   int *next_node, double *weight );

--- a/spatial_mesh.cpp
+++ b/spatial_mesh.cpp
@@ -194,73 +194,54 @@ void Spatial_mesh::print_ongrid_values()
     return;
 }
 
-void Spatial_mesh::write_to_file_iostream( std::ofstream &output_file )
-{
-    int nx = x_n_nodes;
-    int ny = y_n_nodes;
-    int nz = z_n_nodes;
-
-    output_file << "### Grid" << std::endl;
-    output_file << "X volume size = " << x_volume_size << std::endl;
-    output_file << "Y volume size = " << y_volume_size << std::endl;
-    output_file << "Z volume size = " << z_volume_size << std::endl;
-    output_file << "X cell size = " << x_cell_size << std::endl;
-    output_file << "Y cell size = " << y_cell_size << std::endl;
-    output_file << "Z cell size = " << z_cell_size << std::endl;
-    output_file << "X nodes = " << x_n_nodes << std::endl;
-    output_file << "Y nodes = " << y_n_nodes << std::endl;
-    output_file << "Z nodes = " << z_n_nodes << std::endl;
-    output_file << "x_node, y_node, z_node, charge_density, potential, electric_field(x,y,z)" << std::endl;
-    output_file.fill(' ');
-    output_file.setf( std::ios::scientific );
-    output_file.precision( 2 );
-    output_file.setf( std::ios::right );
-    for ( int i = 0; i < nx; i++ ) {
-	for ( int j = 0; j < ny; j++ ) {
-	    for ( int k = 0; k < nz; k++ ) {
-		output_file << std::setw(8) << std::left << i 
-			    << std::setw(8) << std::left << j
-			    << std::setw(8) << std::left << k 
-			    << std::setw(14) << charge_density[i][j][k]
-			    << std::setw(14) << potential[i][j][k]
-			    << std::setw(14) << vec3d_x( electric_field[i][j][k] ) 
-			    << std::setw(14) << vec3d_y( electric_field[i][j][k] )
-			    << std::setw(14) << vec3d_z( electric_field[i][j][k] ) 
-			    << std::endl;
-	    }
-	}
-    }
-    return;
-}
-
-void Spatial_mesh::write_to_file_hdf5( hid_t hdf5_file_id )
+void Spatial_mesh::write_to_file( hid_t hdf5_file_id )
 {
     hid_t group_id;
     herr_t status;
     std::string hdf5_groupname = "/Spatial_mesh";
     group_id = H5Gcreate( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    hdf5_status_check( group_id );
 
     write_hdf5_attributes( group_id );
     write_hdf5_ongrid_values( group_id );
         
-    status = H5Gclose(group_id);
+    status = H5Gclose(group_id); hdf5_status_check( status );
     return;
 }
 
 void Spatial_mesh::write_hdf5_attributes( hid_t group_id )
 {
+    herr_t status;
     int single_element = 1;
     std::string hdf5_current_group = "./";
 
-    H5LTset_attribute_double( group_id, hdf5_current_group.c_str(), "x_volume_size", &x_volume_size, single_element );
-    H5LTset_attribute_double( group_id, hdf5_current_group.c_str(), "y_volume_size", &y_volume_size, single_element );
-    H5LTset_attribute_double( group_id, hdf5_current_group.c_str(), "z_volume_size", &z_volume_size, single_element );
-    H5LTset_attribute_double( group_id, hdf5_current_group.c_str(), "x_cell_size", &x_cell_size, single_element );
-    H5LTset_attribute_double( group_id, hdf5_current_group.c_str(), "y_cell_size", &y_cell_size, single_element );
-    H5LTset_attribute_double( group_id, hdf5_current_group.c_str(), "z_cell_size", &z_cell_size, single_element );
-    H5LTset_attribute_int( group_id, hdf5_current_group.c_str(), "x_n_nodes", &x_n_nodes, single_element );
-    H5LTset_attribute_int( group_id, hdf5_current_group.c_str(), "y_n_nodes", &y_n_nodes, single_element );
-    H5LTset_attribute_int( group_id, hdf5_current_group.c_str(), "z_n_nodes", &z_n_nodes, single_element );
+    status = H5LTset_attribute_double( group_id, hdf5_current_group.c_str(),
+			      "x_volume_size", &x_volume_size, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( group_id, hdf5_current_group.c_str(),
+			      "y_volume_size", &y_volume_size, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( group_id, hdf5_current_group.c_str(),
+			      "z_volume_size", &z_volume_size, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( group_id, hdf5_current_group.c_str(),
+			      "x_cell_size", &x_cell_size, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( group_id, hdf5_current_group.c_str(),
+			      "y_cell_size", &y_cell_size, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_double( group_id, hdf5_current_group.c_str(),
+			      "z_cell_size", &z_cell_size, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_int( group_id, hdf5_current_group.c_str(),
+			   "x_n_nodes", &x_n_nodes, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_int( group_id, hdf5_current_group.c_str(),
+			   "y_n_nodes", &y_n_nodes, single_element );
+    hdf5_status_check( status );
+    status = H5LTset_attribute_int( group_id, hdf5_current_group.c_str(),
+			   "z_n_nodes", &z_n_nodes, single_element );
+    hdf5_status_check( status );
 }
 
 void Spatial_mesh::write_hdf5_ongrid_values( hid_t group_id )
@@ -275,8 +256,8 @@ void Spatial_mesh::write_hdf5_ongrid_values( hid_t group_id )
     
     compound_type_for_mem = vec3d_hdf5_compound_type_for_memory();
     compound_type_for_file = vec3d_hdf5_compound_type_for_file();
-    plist_id = H5Pcreate( H5P_DATASET_XFER );
-    H5Pset_dxpl_mpio( plist_id, H5FD_MPIO_COLLECTIVE ); 
+    plist_id = H5Pcreate( H5P_DATASET_XFER ); hdf5_status_check( plist_id );
+    status = H5Pset_dxpl_mpio( plist_id, H5FD_MPIO_COLLECTIVE ); hdf5_status_check( status ); 
     
     subset_dims[0] = n_of_elements_to_write_for_each_process_for_1d_dataset( dims[0] );
     subset_offset[0] = data_offset_for_each_process_for_1d_dataset( dims[0] );
@@ -290,33 +271,42 @@ void Spatial_mesh::write_hdf5_ongrid_values( hid_t group_id )
 	      << "count = " << subset_dims[0] << " "
 	      << "offset = " << subset_offset[0] << std::endl;
     
-    memspace = H5Screate_simple( rank, subset_dims, NULL );
-    filespace = H5Screate_simple( rank, dims, NULL );
-    H5Sselect_hyperslab( filespace, H5S_SELECT_SET, subset_offset, NULL, subset_dims, NULL );
+    memspace = H5Screate_simple( rank, subset_dims, NULL ); hdf5_status_check( memspace );
+    filespace = H5Screate_simple( rank, dims, NULL ); hdf5_status_check( filespace );
+    status = H5Sselect_hyperslab( filespace, H5S_SELECT_SET, subset_offset, NULL, subset_dims, NULL );
+    hdf5_status_check( status );
 
     dset = H5Dcreate( group_id, "./node_coordinates",
 		      compound_type_for_file, filespace,
-		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
-    status = H5Dwrite( dset, compound_type_for_mem, memspace, filespace, plist_id, node_coordinates.data() );
-    status = H5Dclose( dset );
+		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); hdf5_status_check( dset );
+    status = H5Dwrite( dset, compound_type_for_mem,
+		       memspace, filespace, plist_id,
+		       ( node_coordinates.data() + subset_offset[0] ) ); hdf5_status_check( status );
+    status = H5Dclose( dset ); hdf5_status_check( status );
 
     dset = H5Dcreate( group_id, "./charge_density",
 		      H5T_IEEE_F64BE, filespace,
-		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
-    status = H5Dwrite( dset, H5T_NATIVE_DOUBLE, memspace, filespace, plist_id, charge_density.data() );
-    status = H5Dclose( dset );
+		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); hdf5_status_check( dset );
+    status = H5Dwrite( dset, H5T_NATIVE_DOUBLE,
+		       memspace, filespace, plist_id,
+		       ( charge_density.data() + subset_offset[0] ) ); hdf5_status_check( status );
+    status = H5Dclose( dset ); hdf5_status_check( status );
 
     dset = H5Dcreate( group_id, "./potential",
 		      H5T_IEEE_F64BE, filespace,
-		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
-    status = H5Dwrite( dset, H5T_NATIVE_DOUBLE, memspace, filespace, plist_id, potential.data() );
-    status = H5Dclose( dset );
+		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); hdf5_status_check( dset );
+    status = H5Dwrite( dset, H5T_NATIVE_DOUBLE,
+		       memspace, filespace, plist_id,
+		       ( potential.data() + subset_offset[0] ) ); hdf5_status_check( status );
+    status = H5Dclose( dset ); hdf5_status_check( status );
 
     dset = H5Dcreate( group_id, "./electric_field",
 		      compound_type_for_file, filespace,
-		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
-    status = H5Dwrite( dset, compound_type_for_mem, memspace, filespace, plist_id, electric_field.data() );
-    status = H5Dclose( dset );
+		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); hdf5_status_check( dset );
+    status = H5Dwrite( dset, compound_type_for_mem,
+		       memspace, filespace, plist_id,
+		       ( electric_field.data() + subset_offset[0] ) ); hdf5_status_check( status );
+    status = H5Dclose( dset ); hdf5_status_check( status );
 
     // for testing
     int *mpi_proc_ranks = new int[ dims[0] ];
@@ -325,17 +315,19 @@ void Spatial_mesh::write_hdf5_ongrid_values( hid_t group_id )
     }
     dset = H5Dcreate( group_id, "./mpi_proc",
 		      H5T_STD_I32BE, filespace,
-		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT );
-    status = H5Dwrite( dset, H5T_NATIVE_INT, memspace, filespace, plist_id, mpi_proc_ranks );
-    status = H5Dclose( dset );
+		      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ); hdf5_status_check( dset );
+    status = H5Dwrite( dset, H5T_NATIVE_INT,
+		       memspace, filespace, plist_id,
+		       ( mpi_proc_ranks + subset_offset[0] ) ); hdf5_status_check( status );
+    status = H5Dclose( dset ); hdf5_status_check( status );
     delete[] mpi_proc_ranks;
     //
     
-    status = H5Sclose( filespace );
-    status = H5Sclose( memspace );
-    status = H5Pclose( plist_id );
-    status = H5Tclose( compound_type_for_file );
-    status = H5Tclose( compound_type_for_mem );	
+    status = H5Sclose( filespace ); hdf5_status_check( status );
+    status = H5Sclose( memspace ); hdf5_status_check( status );
+    status = H5Pclose( plist_id ); hdf5_status_check( status );
+    status = H5Tclose( compound_type_for_file ); hdf5_status_check( status );
+    status = H5Tclose( compound_type_for_mem );	hdf5_status_check( status );
 }
 
 int Spatial_mesh::n_of_elements_to_write_for_each_process_for_1d_dataset( int total_elements )
@@ -458,5 +450,13 @@ double Spatial_mesh::node_number_to_coordinate_z( int k )
     }
 }
 
+void Spatial_mesh::hdf5_status_check( herr_t status )
+{
+    if( status < 0 ){
+	std::cout << "Something went wrong while writing Spatial_mesh group. Aborting."
+		  << std::endl;
+	exit( EXIT_FAILURE );
+    }
+}
 
 Spatial_mesh::~Spatial_mesh() {}

--- a/spatial_mesh.h
+++ b/spatial_mesh.h
@@ -27,8 +27,7 @@ class Spatial_mesh {
     void clear_old_density_values();
     void set_boundary_conditions( Config &conf );
     void print();
-    void write_to_file_iostream( std::ofstream &output_file );
-    void write_to_file_hdf5( hid_t hdf5_file_id );
+    void write_to_file( hid_t hdf5_file_id );
     virtual ~Spatial_mesh();
     double node_number_to_coordinate_x( int i );
     double node_number_to_coordinate_y( int j );
@@ -52,6 +51,7 @@ class Spatial_mesh {
     void write_hdf5_ongrid_values( hid_t group_id );
     int n_of_elements_to_write_for_each_process_for_1d_dataset( int total_elements );
     int data_offset_for_each_process_for_1d_dataset( int total_elements );
+    void hdf5_status_check( herr_t status );
     // config check
     void grid_x_size_gt_zero( Config &conf );
     void grid_x_step_gt_zero_le_grid_x_size( Config &conf );

--- a/spatial_mesh.h
+++ b/spatial_mesh.h
@@ -50,6 +50,8 @@ class Spatial_mesh {
     // write hdf5
     void write_hdf5_attributes( hid_t group_id );
     void write_hdf5_ongrid_values( hid_t group_id );
+    int n_of_elements_to_write_for_each_process_for_1d_dataset( int total_elements );
+    int data_offset_for_each_process_for_1d_dataset( int total_elements );
     // config check
     void grid_x_size_gt_zero( Config &conf );
     void grid_x_step_gt_zero_le_grid_x_size( Config &conf );

--- a/spatial_mesh.h
+++ b/spatial_mesh.h
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <iomanip>
 #include <boost/multi_array.hpp>
+#include <hdf5.h>
+#include <hdf5_hl.h>
 #include "config.h"
 #include "vec3d.h"
 
@@ -15,6 +17,7 @@ class Spatial_mesh {
     double x_volume_size, y_volume_size, z_volume_size;
     double x_cell_size, y_cell_size, z_cell_size;
     int x_n_nodes, y_n_nodes, z_n_nodes;
+    boost::multi_array<Vec3d, 3> node_coordinates;
     boost::multi_array<double, 3> charge_density;
     boost::multi_array<double, 3> potential;
     boost::multi_array<Vec3d, 3> electric_field;
@@ -23,7 +26,8 @@ class Spatial_mesh {
     void clear_old_density_values();
     void set_boundary_conditions( Config &conf );
     void print();
-    void write_to_file( std::ofstream &output_file );
+    void write_to_file_iostream( std::ofstream &output_file );
+    void write_to_file_hdf5( hid_t hdf5_file_id );
     virtual ~Spatial_mesh();
     double node_number_to_coordinate_x( int i );
     double node_number_to_coordinate_y( int j );
@@ -34,13 +38,17 @@ class Spatial_mesh {
     void init_x_grid( Config &conf );
     void init_y_grid( Config &conf );
     void init_z_grid( Config &conf );
-    void allocate_ongrid_values( );
+    void allocate_ongrid_values();
+    void fill_node_coordinates();
     void set_boundary_conditions( const double phi_left, const double phi_right,
 				  const double phi_top, const double phi_bottom,
 				  const double phi_near, const double phi_far );
     // print
-    void print_grid( );
-    void print_ongrid_values( );
+    void print_grid();
+    void print_ongrid_values();
+    // write hdf5
+    void write_hdf5_attributes( hid_t group_id );
+    void write_hdf5_ongrid_values( hid_t group_id );
     // config check
     void grid_x_size_gt_zero( Config &conf );
     void grid_x_step_gt_zero_le_grid_x_size( Config &conf );

--- a/spatial_mesh.h
+++ b/spatial_mesh.h
@@ -8,6 +8,7 @@
 #include <boost/multi_array.hpp>
 #include <hdf5.h>
 #include <hdf5_hl.h>
+#include <mpi.h>
 #include "config.h"
 #include "vec3d.h"
 

--- a/test.conf
+++ b/test.conf
@@ -40,9 +40,9 @@ inner_region_box_y_top = 0.4
 inner_region_box_z_near = 0.8
 inner_region_box_z_far = 0.9
 
-# [Inner_region_with_model.first_model]
-# inner_region_with_model_potential = -100.0
-# inner_region_with_model_file = "nut.step"
+# [Inner_region_STEP.first_model]
+# inner_region_STEP_potential = -100.0
+# inner_region_STEP_file = "nut.step"
 
 [Boundary conditions]
 boundary_phi_left = 0.0

--- a/test.conf
+++ b/test.conf
@@ -8,16 +8,16 @@ time_save_step = 1.0e-8
 
 [Spatial mesh]
 grid_x_size = 1.0
-grid_x_step = 0.01
+grid_x_step = 0.3
 grid_y_size = 2.0
-grid_y_step = 0.02
+grid_y_step = 0.6
 grid_z_size = 5.0
-grid_z_step = 0.05
+grid_z_step = 1.5
 
 
 [Source.test_bottom]
-particle_source_initial_number_of_particles = 1000000
-particle_source_particles_to_generate_each_step = 10000
+particle_source_initial_number_of_particles = 1000
+particle_source_particles_to_generate_each_step = 1000
 particle_source_x_left = 0.45
 particle_source_x_right = 0.55
 particle_source_y_bottom = 0.95
@@ -32,8 +32,8 @@ particle_source_charge = -1.5e-7
 particle_source_mass = 2.8e-25
 
 [Source.top]
-particle_source_initial_number_of_particles = 10000
-particle_source_particles_to_generate_each_step = 10000
+particle_source_initial_number_of_particles = 1000
+particle_source_particles_to_generate_each_step = 1000
 particle_source_x_left = 0.45
 particle_source_x_right = 0.55
 particle_source_y_bottom = 0.95
@@ -79,5 +79,5 @@ speed_of_light = 3.0e10
 
 [Output filename]
 # No quotes; no spaces till end of line
-output_filename_prefix = out/out_hdf5output_
+output_filename_prefix = out/out_prll_particles_
 output_filename_suffix = .h5

--- a/test.conf
+++ b/test.conf
@@ -16,20 +16,39 @@ grid_z_step = 0.05
 
 
 [Source.test_bottom]
-particle_source_initial_number_of_particles = 1000000
+particle_source_initial_number_of_particles = 10000
 particle_source_particles_to_generate_each_step = 10000
 particle_source_x_left = 0.45
 particle_source_x_right = 0.55
 particle_source_y_bottom = 0.95
 particle_source_y_top = 1.05
-particle_source_z_near = 2.45
-particle_source_z_far = 2.55
+particle_source_z_near = 1.45
+particle_source_z_far = 1.55
 particle_source_mean_momentum_x = 0.0
 particle_source_mean_momentum_y = 0.0
 particle_source_mean_momentum_z = 9.5e-19
 particle_source_temperature = 0.0
 particle_source_charge = -1.5e-7
 particle_source_mass = 2.8e-25
+
+[Source.top]
+particle_source_initial_number_of_particles = 10000
+particle_source_particles_to_generate_each_step = 10000
+particle_source_x_left = 0.45
+particle_source_x_right = 0.55
+particle_source_y_bottom = 0.95
+particle_source_y_top = 1.05
+particle_source_z_near = 4.45
+particle_source_z_far = 4.55
+particle_source_mean_momentum_x = 0.0
+particle_source_mean_momentum_y = 0.0
+particle_source_mean_momentum_z = 9.5e-19
+particle_source_temperature = 0.0
+particle_source_charge = -1.5e-7
+particle_source_mass = 2.8e-25
+
+
+
 
 [Inner_region_box.first_inner_object]
 inner_region_box_potential = 300.0
@@ -60,5 +79,5 @@ speed_of_light = 3.0e10
 
 [Output filename]
 # No quotes; no spaces till end of line
-output_filename_prefix = out/out_petsc3d_test_inner_object_
-output_filename_suffix = .dat
+output_filename_prefix = out/out_hdf5output_
+output_filename_suffix = .h5

--- a/test.conf
+++ b/test.conf
@@ -2,7 +2,7 @@
 # Do not change section and field names.
 
 [Time grid]
-total_time = 5.0e-9
+total_time = 1.0e-9
 time_step_size = 1.0e-9
 time_save_step = 1.0e-8
 
@@ -16,7 +16,7 @@ grid_z_step = 0.05
 
 
 [Source.test_bottom]
-particle_source_initial_number_of_particles = 10000
+particle_source_initial_number_of_particles = 1000000
 particle_source_particles_to_generate_each_step = 10000
 particle_source_x_left = 0.45
 particle_source_x_right = 0.55

--- a/time_grid.cpp
+++ b/time_grid.cpp
@@ -98,7 +98,7 @@ void Time_grid::write_to_file_hdf5( hid_t hdf5_file_id )
     herr_t status;
     int single_element = 1;
     std::string hdf5_groupname = "/Time_grid";
-    group_id = H5Gcreate2( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    group_id = H5Gcreate( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "total_time", &total_time, single_element );
     H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "current_time", &current_time, single_element );
@@ -108,7 +108,7 @@ void Time_grid::write_to_file_hdf5( hid_t hdf5_file_id )
     H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "current_node", &current_node, single_element );
     H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "node_to_save", &node_to_save, single_element );
 	
-    status = H5Gclose(group_id);	
+    status = H5Gclose(group_id);
     return;
 }
 

--- a/time_grid.cpp
+++ b/time_grid.cpp
@@ -68,7 +68,7 @@ void Time_grid::update_to_next_step()
 
 void Time_grid::print( )
 {
-    std::cout << "Time grid:" << std::endl;
+    std::cout << "### Time grid:" << std::endl;
     std::cout << "Total time = " << total_time << std::endl;
     std::cout << "Current time = " << current_time << std::endl;
     std::cout << "Time step size = " << time_step_size << std::endl;
@@ -81,7 +81,7 @@ void Time_grid::print( )
 
 void Time_grid::write_to_file_iostream( std::ofstream &output_file )
 {
-    output_file << "Time grid:" << std::endl;
+    output_file << "### Time grid:" << std::endl;
     output_file << "Total time = " << total_time << std::endl;
     output_file << "Current time = " << current_time << std::endl;
     output_file << "Time step size = " << time_step_size << std::endl;

--- a/time_grid.cpp
+++ b/time_grid.cpp
@@ -79,7 +79,7 @@ void Time_grid::print( )
     return;
 }
 
-void Time_grid::write_to_file( std::ofstream &output_file )
+void Time_grid::write_to_file_iostream( std::ofstream &output_file )
 {
     output_file << "Time grid:" << std::endl;
     output_file << "Total time = " << total_time << std::endl;
@@ -89,6 +89,26 @@ void Time_grid::write_to_file( std::ofstream &output_file )
     output_file << "Total nodes = " << total_nodes << std::endl;
     output_file << "Current node = " << current_node << std::endl;
     output_file << "Node to save = " << node_to_save << std::endl;
+    return;
+}
+
+void Time_grid::write_to_file_hdf5( hid_t hdf5_file_id )
+{
+    hid_t group_id;
+    herr_t status;
+    int single_element = 1;
+    std::string hdf5_groupname = "/Time_grid";
+    group_id = H5Gcreate2( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "total_time", &total_time, single_element );
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "current_time", &current_time, single_element );
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "time_step_size", &time_step_size, single_element );
+    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "time_save_step", &time_save_step, single_element );
+    H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "total_nodes", &total_nodes, single_element );
+    H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "current_node", &current_node, single_element );
+    H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "node_to_save", &node_to_save, single_element );
+	
+    status = H5Gclose(group_id);	
     return;
 }
 

--- a/time_grid.cpp
+++ b/time_grid.cpp
@@ -79,37 +79,41 @@ void Time_grid::print( )
     return;
 }
 
-void Time_grid::write_to_file_iostream( std::ofstream &output_file )
-{
-    output_file << "### Time grid:" << std::endl;
-    output_file << "Total time = " << total_time << std::endl;
-    output_file << "Current time = " << current_time << std::endl;
-    output_file << "Time step size = " << time_step_size << std::endl;
-    output_file << "Time save step = " << time_save_step << std::endl;
-    output_file << "Total nodes = " << total_nodes << std::endl;
-    output_file << "Current node = " << current_node << std::endl;
-    output_file << "Node to save = " << node_to_save << std::endl;
-    return;
-}
-
-void Time_grid::write_to_file_hdf5( hid_t hdf5_file_id )
+void Time_grid::write_to_file( hid_t hdf5_file_id )
 {
     hid_t group_id;
     herr_t status;
     int single_element = 1;
     std::string hdf5_groupname = "/Time_grid";
-    group_id = H5Gcreate( hdf5_file_id, hdf5_groupname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    group_id = H5Gcreate( hdf5_file_id, hdf5_groupname.c_str(),
+			  H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); hdf5_status_check( group_id );
 
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "total_time", &total_time, single_element );
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "current_time", &current_time, single_element );
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "time_step_size", &time_step_size, single_element );
-    H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(), "time_save_step", &time_save_step, single_element );
-    H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "total_nodes", &total_nodes, single_element );
-    H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "current_node", &current_node, single_element );
-    H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(), "node_to_save", &node_to_save, single_element );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "total_time", &total_time, single_element ); hdf5_status_check( status );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "current_time", &current_time, single_element ); hdf5_status_check( status );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "time_step_size", &time_step_size, single_element ); hdf5_status_check( status );
+    status = H5LTset_attribute_double( hdf5_file_id, hdf5_groupname.c_str(),
+				       "time_save_step", &time_save_step, single_element ); hdf5_status_check( status );
+    status = H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(),
+				    "total_nodes", &total_nodes, single_element ); hdf5_status_check( status );
+    status = H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(),
+				    "current_node", &current_node, single_element ); hdf5_status_check( status );
+    status = H5LTset_attribute_int( hdf5_file_id, hdf5_groupname.c_str(),
+				    "node_to_save", &node_to_save, single_element ); hdf5_status_check( status );
 	
-    status = H5Gclose(group_id);
+    status = H5Gclose(group_id); hdf5_status_check( status );
     return;
+}
+
+void Time_grid::hdf5_status_check( herr_t status )
+{
+    if( status < 0 ){
+	std::cout << "Something went wrong while writing Time_grid group. Aborting."
+		  << std::endl;
+	exit( EXIT_FAILURE );
+    }
 }
 
 void Time_grid::total_time_gt_zero( Config &conf )

--- a/time_grid.h
+++ b/time_grid.h
@@ -19,8 +19,7 @@ class Time_grid {
     Time_grid( Config &conf );
     void update_to_next_step();
     void print();
-    void write_to_file_iostream( std::ofstream &output_file );
-    void write_to_file_hdf5( hid_t hdf5_file_id );
+    void write_to_file( hid_t hdf5_file_id );
   private:
     // initialisation
     void check_correctness_of_related_config_fields( Config &conf );
@@ -34,6 +33,8 @@ class Time_grid {
     void time_step_size_gt_zero_le_total_time( Config &conf );
     void time_save_step_ge_time_step_size( Config &conf );
     void check_and_exit_if_not( const bool &should_be, const std::string &message );
+    // write to file
+    void hdf5_status_check( herr_t status );
 }; 
 
 #endif /* _TIME_GRID_H_ */

--- a/time_grid.h
+++ b/time_grid.h
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <iostream>
 #include <string>
+#include <hdf5.h>
+#include <hdf5_hl.h>
 #include "config.h"
 
 class Time_grid {
@@ -16,7 +18,8 @@ class Time_grid {
     Time_grid( Config &conf );
     void update_to_next_step();
     void print();
-    void write_to_file( std::ofstream &output_file );
+    void write_to_file_iostream( std::ofstream &output_file );
+    void write_to_file_hdf5( hid_t hdf5_file_id );
   private:
     // initialisation
     void check_correctness_of_related_config_fields( Config &conf );

--- a/time_grid.h
+++ b/time_grid.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <iostream>
 #include <string>
+#include <mpi.h>
 #include <hdf5.h>
 #include <hdf5_hl.h>
 #include "config.h"

--- a/vec3d.cpp
+++ b/vec3d.cpp
@@ -81,12 +81,16 @@ hid_t vec3d_hdf5_compound_type_for_memory()
     hid_t compound_type_for_mem;
     herr_t status;
     compound_type_for_mem = H5Tcreate( H5T_COMPOUND, sizeof(Vec3d) );
+    vec3d_hdf5_status_check( compound_type_for_mem );
     status = H5Tinsert( compound_type_for_mem, "vec_x",
 			HOFFSET( Vec3d, x ), H5T_NATIVE_DOUBLE );
+    vec3d_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "vec_y",
 			HOFFSET( Vec3d, x ) + sizeof(double), H5T_NATIVE_DOUBLE );
+    vec3d_hdf5_status_check( status );
     status = H5Tinsert( compound_type_for_mem, "vec_z",
 			HOFFSET( Vec3d, x ) + 2 * sizeof(double), H5T_NATIVE_DOUBLE );
+    vec3d_hdf5_status_check( status );
     return compound_type_for_mem;
 }
 
@@ -94,11 +98,25 @@ hid_t vec3d_hdf5_compound_type_for_file()
 {
     hid_t compound_type_for_file;
     herr_t status;
-
-    compound_type_for_file = H5Tcreate( H5T_COMPOUND, 8 + 8 + 8 );
+    int double_size_in_file = 8;
+    
+    compound_type_for_file = H5Tcreate( H5T_COMPOUND, 3 * double_size_in_file );
+    vec3d_hdf5_status_check( compound_type_for_file );
     status = H5Tinsert( compound_type_for_file, "vec_x", 0, H5T_IEEE_F64BE);
-    status = H5Tinsert( compound_type_for_file, "vec_y", 8, H5T_IEEE_F64BE );
-    status = H5Tinsert( compound_type_for_file, "vec_z", 8 + 8, H5T_IEEE_F64BE );
+    vec3d_hdf5_status_check( status );
+    status = H5Tinsert( compound_type_for_file, "vec_y", double_size_in_file, H5T_IEEE_F64BE );
+    vec3d_hdf5_status_check( status );
+    status = H5Tinsert( compound_type_for_file, "vec_z", 2 * double_size_in_file, H5T_IEEE_F64BE );
+    vec3d_hdf5_status_check( status );
 
     return compound_type_for_file;
+}
+
+void vec3d_hdf5_status_check( herr_t status )
+{
+    if( status < 0 ){
+	std::cout << "Something went wrong while creating compound datatypes for Vec3d. Aborting."
+		  << std::endl;
+	exit( EXIT_FAILURE );
+    }
 }

--- a/vec3d.cpp
+++ b/vec3d.cpp
@@ -75,3 +75,30 @@ void vec3d_print( Vec3d v )
     printf("(%e, %e, %e)",
 	   vec3d_x(v), vec3d_y(v), vec3d_z(v) );
 }
+
+hid_t vec3d_hdf5_compound_type_for_memory()
+{
+    hid_t compound_type_for_mem;
+    herr_t status;
+    compound_type_for_mem = H5Tcreate( H5T_COMPOUND, sizeof(Vec3d) );
+    status = H5Tinsert( compound_type_for_mem, "vec_x",
+			HOFFSET( Vec3d, x ), H5T_NATIVE_DOUBLE );
+    status = H5Tinsert( compound_type_for_mem, "vec_y",
+			HOFFSET( Vec3d, x ) + sizeof(double), H5T_NATIVE_DOUBLE );
+    status = H5Tinsert( compound_type_for_mem, "vec_z",
+			HOFFSET( Vec3d, x ) + 2 * sizeof(double), H5T_NATIVE_DOUBLE );
+    return compound_type_for_mem;
+}
+
+hid_t vec3d_hdf5_compound_type_for_file()
+{
+    hid_t compound_type_for_file;
+    herr_t status;
+
+    compound_type_for_file = H5Tcreate( H5T_COMPOUND, 8 + 8 + 8 );
+    status = H5Tinsert( compound_type_for_file, "vec_x", 0, H5T_IEEE_F64BE);
+    status = H5Tinsert( compound_type_for_file, "vec_y", 8, H5T_IEEE_F64BE );
+    status = H5Tinsert( compound_type_for_file, "vec_z", 8 + 8, H5T_IEEE_F64BE );
+
+    return compound_type_for_file;
+}

--- a/vec3d.h
+++ b/vec3d.h
@@ -22,6 +22,6 @@ Vec3d vec3d_times_scalar( Vec3d v, double a );
 void vec3d_print( Vec3d v );
 hid_t vec3d_hdf5_compound_type_for_memory();
 hid_t vec3d_hdf5_compound_type_for_file();
-
+void vec3d_hdf5_status_check( herr_t status );
 
 #endif /* _VEC_H_ */

--- a/vec3d.h
+++ b/vec3d.h
@@ -2,6 +2,7 @@
 #define _VEC_H_
 
 #include <stdio.h>
+#include <hdf5.h>
 
 typedef struct {
     double x[3];
@@ -19,5 +20,8 @@ double vec3d_dot_product( Vec3d v1, Vec3d v2 );
 Vec3d vec3d_cross_product( Vec3d v1, Vec3d v2 );
 Vec3d vec3d_times_scalar( Vec3d v, double a );
 void vec3d_print( Vec3d v );
+hid_t vec3d_hdf5_compound_type_for_memory();
+hid_t vec3d_hdf5_compound_type_for_file();
+
 
 #endif /* _VEC_H_ */


### PR DESCRIPTION
Создал на githab'е "организацию" - возможно, это несколько упростит процесс обмена изменениями в коде. 
Приглашение должно было прийти тебе на почту. 

Еще из интересного - включил распараллеливание по частицам. Т.е. теперь каждый mpi-процесс обрабатывает только свою часть частиц.

Поменял формат выходных фаилов. Новый формат - hdf5. Запись в фаил теперь тоже распараллелена. 
Для сборки программы придется установить соответствующие библиотеки: у меня в debian это libhdf5-mpi-dev.
Просматривать содержимое фаилов удобно программой hdfview. Также есть инструменты для командной строки - в пакете hdf5-tools.
 
Все изменения лежат в ветке dev